### PR TITLE
feat(scripts): add Quay image bump helper and smoke target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,15 @@ validate: ## run full validation (lint, render, schema, policy)
 smoke: ## run cluster smoke checks (ENV=<env> [BOOTSTRAP=true] [BASE_DOMAIN=...])
 	@ENV=${ENV} BOOTSTRAP=${BOOTSTRAP} BASE_DOMAIN=${BASE_DOMAIN} bash scripts/smoke.sh ${ENV}
 
+smoke-image-update: ## tail updater logs and show app annotations (ENV=<env> NS=openshift-gitops)
+	@bash scripts/smoke-image-update.sh
+
+bump-image: ## create a new tag in Quay from SOURCE_TAG to NEW_TAG (uses skopeo|podman|docker)
+	@bash scripts/quay-bump-tag.sh
+
+bump-and-tail: ## bump image in Quay then tail updater logs (ENV=<env> NS=openshift-gitops)
+	@bash scripts/quay-bump-tag.sh && bash scripts/smoke-image-update.sh
+
 tekton-setup: ## create image ns + grant pusher; create webhook secret if GITHUB_WEBHOOK_SECRET is set
 	@oc new-project bitiq-ci >/dev/null 2>&1 || true
 	@oc policy add-role-to-user system:image-pusher system:serviceaccount:openshift-pipelines:pipeline -n bitiq-ci >/dev/null 2>&1 || true

--- a/charts/bitiq-umbrella/templates/app-bitiq-sample-app.yaml
+++ b/charts/bitiq-umbrella/templates/app-bitiq-sample-app.yaml
@@ -12,6 +12,8 @@ metadata:
     argocd-image-updater.argoproj.io/app.helm.image-tag: image.tag
     argocd-image-updater.argoproj.io/write-back-method: git
     argocd-image-updater.argoproj.io/write-back-target: helmvalues:/charts/bitiq-sample-app/values-{{ .Values.env }}.yaml
+    argocd-image-updater.argoproj.io/git-branch: {{ .Values.targetRevision }}
+    argocd-image-updater.argoproj.io/dry-run: "false"
 spec:
   project: default
   source:

--- a/scripts/quay-bump-tag.sh
+++ b/scripts/quay-bump-tag.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bump (retag) an image in Quay by creating a new tag pointing to the
+# same manifest as an existing source tag.
+#
+# Prefers skopeo if available, then podman, then docker.
+#
+# Env vars (with defaults for this repo's sample image):
+#   QUAY_REGISTRY   - default: quay.io
+#   QUAY_NAMESPACE  - default: paulcapestany
+#   QUAY_REPOSITORY - default: toy-service
+#   SOURCE_TAG      - default: latest
+#   NEW_TAG         - default: dev-$(date +%Y%m%d-%H%M%S)
+#   QUAY_USERNAME   - optional (for login/creds)
+#   QUAY_PASSWORD   - optional (for login/creds)
+#
+# Examples:
+#   QUAY_USERNAME=... QUAY_PASSWORD=... \
+#   NEW_TAG=test-$(date +%s) make bump-image
+#
+
+QUAY_REGISTRY="${QUAY_REGISTRY:-quay.io}"
+QUAY_NAMESPACE="${QUAY_NAMESPACE:-paulcapestany}"
+QUAY_REPOSITORY="${QUAY_REPOSITORY:-toy-service}"
+SOURCE_TAG="${SOURCE_TAG:-latest}"
+NEW_TAG="${NEW_TAG:-dev-$(date +%Y%m%d-%H%M%S)}"
+
+image_ref_src="${QUAY_REGISTRY}/${QUAY_NAMESPACE}/${QUAY_REPOSITORY}:${SOURCE_TAG}"
+image_ref_new="${QUAY_REGISTRY}/${QUAY_NAMESPACE}/${QUAY_REPOSITORY}:${NEW_TAG}"
+
+log() { echo "[quay-bump] $*"; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+if have skopeo; then
+  log "Using skopeo to retag ${image_ref_src} -> ${image_ref_new}"
+  # Build creds args if provided
+  creds_args=()
+  if [[ -n "${QUAY_USERNAME:-}" && -n "${QUAY_PASSWORD:-}" ]]; then
+    creds_args+=("--src-creds=${QUAY_USERNAME}:${QUAY_PASSWORD}")
+    creds_args+=("--dest-creds=${QUAY_USERNAME}:${QUAY_PASSWORD}")
+  fi
+  skopeo copy --all "docker://${image_ref_src}" "docker://${image_ref_new}" "${creds_args[@]}"
+  log "Created tag ${NEW_TAG} in ${QUAY_NAMESPACE}/${QUAY_REPOSITORY}"
+  exit 0
+fi
+
+if have podman; then
+  log "Using podman to retag ${image_ref_src} -> ${image_ref_new}"
+  if [[ -n "${QUAY_USERNAME:-}" && -n "${QUAY_PASSWORD:-}" ]]; then
+    log "Podman login to ${QUAY_REGISTRY} as ${QUAY_USERNAME}"
+    podman login "${QUAY_REGISTRY}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" >/dev/null
+  fi
+  podman pull "${image_ref_src}"
+  podman tag "${image_ref_src}" "${image_ref_new}"
+  podman push "${image_ref_new}"
+  log "Created tag ${NEW_TAG} in ${QUAY_NAMESPACE}/${QUAY_REPOSITORY}"
+  exit 0
+fi
+
+if have docker; then
+  log "Using docker to retag ${image_ref_src} -> ${image_ref_new}"
+  if [[ -n "${QUAY_USERNAME:-}" && -n "${QUAY_PASSWORD:-}" ]]; then
+    log "Docker login to ${QUAY_REGISTRY} as ${QUAY_USERNAME}"
+    echo "${QUAY_PASSWORD}" | docker login "${QUAY_REGISTRY}" -u "${QUAY_USERNAME}" --password-stdin >/dev/null
+  fi
+  docker pull "${image_ref_src}"
+  docker tag "${image_ref_src}" "${image_ref_new}"
+  docker push "${image_ref_new}"
+  log "Created tag ${NEW_TAG} in ${QUAY_NAMESPACE}/${QUAY_REPOSITORY}"
+  exit 0
+fi
+
+log "No supported tool found (skopeo/podman/docker). Install one to perform the retag."
+exit 1
+

--- a/scripts/smoke-image-update.sh
+++ b/scripts/smoke-image-update.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tiny smoke helper for Argo CD Image Updater
+# - Shows annotations on the Application (write-back, branch, dry-run)
+# - Prints sourceType so you can see when Argo marks it as Helm
+# - Tails the updater logs for live feedback (Ctrl-C to stop)
+#
+# Usage:
+#   ENV=local NS=openshift-gitops make smoke-image-update
+# or directly:
+#   ENV=local NS=openshift-gitops bash scripts/smoke-image-update.sh
+
+ENV="${ENV:-local}"
+NS="${NS:-openshift-gitops}"
+APP="bitiq-sample-app-${ENV}"
+
+require() { command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }; }
+
+require oc
+
+if ! oc whoami >/dev/null 2>&1; then
+  echo "Not logged into a cluster (oc whoami failed)" >&2
+  exit 1
+fi
+
+if ! oc -n "$NS" get application "$APP" >/dev/null 2>&1; then
+  echo "Application '$APP' not found in namespace '$NS'" >&2
+  exit 1
+fi
+
+echo "==> Application: $NS/$APP"
+echo "==> Annotations (sanity check)"
+# Show the annotations block for easy visual verification
+oc -n "$NS" get application "$APP" -o yaml | sed -n '/^  annotations:/,/^  [^ ]/p' || true
+
+echo
+echo -n "==> ArgoCD sourceType: "
+oc -n "$NS" get application "$APP" -o jsonpath='{.status.sourceType}' 2>/dev/null || true
+echo
+
+echo
+echo "==> Recent updater logs (last 10m)"
+oc -n "$NS" logs deploy/argocd-image-updater --since=10m 2>/dev/null | tail -n 200 || true
+
+cat <<'EOF'
+
+Key lines to look for:
+  - Dry run - not committing ...          => disable dry-run on the Application
+  - Committing changes to application ...  => updater is writing to Git
+  - Pushed change                         => Git push succeeded
+
+Starting live log tail (Ctrl-C to stop)...
+EOF
+
+oc -n "$NS" logs deploy/argocd-image-updater -f --since=1m
+


### PR DESCRIPTION
- fix(umbrella): pin write-back branch and disable dry-run
- docs: correct helmvalues write-back target path and add usage
- chore: smoke-image-update to tail logs + verify annotations

Notes:
- bump helper prefers skopeo, then podman, then docker
- write-back branch uses .Values.targetRevision; dry-run disabled via app annotation