### PR TITLE
fix(charts): default ENV=local platform to amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Local env note (frontend disabled by default)
 Ensure ArgoCD has repo creds with **write access** (SSH key or token). Image Updater will commit to the repo branch Argo tracks. ([Argo CD Image Updater][10])
 
 Platform and private registry notes:
-- Platform filter: the umbrella chart exposes `imageUpdater.platforms` (default `linux/amd64`) used by annotations to filter manifest architectures during tag selection. By default, env mapping is: `local -> linux/arm64`, `sno/prod -> linux/amd64` (configured in `charts/argocd-apps/values.yaml` under `envs[].platforms`). Set to match your cluster nodes, or push multi‑arch tags.
+- Platform filter: the umbrella chart exposes `imageUpdater.platforms` (default `linux/amd64`) used by annotations to filter manifest architectures during tag selection. All environments map to `linux/amd64` by default (configured in `charts/argocd-apps/values.yaml` under `envs[].platforms`). Override to `linux/arm64` if your cluster nodes are arm64 (for example, Apple Silicon CRC).
 - Private Quay repos: set `imageUpdater.pullSecret` to a Secret visible to the Argo CD namespace to allow Image Updater to list tags for private repos (annotation `*.pull-secret` is rendered when set). The secret can be referenced as `name` (in `openshift-gitops`) or `namespace/name`.
   Example (secret in openshift-gitops):
   ```bash

--- a/charts/argocd-apps/values.yaml
+++ b/charts/argocd-apps/values.yaml
@@ -15,7 +15,7 @@ envs:
     clusterServer: https://kubernetes.default.svc   # in-cluster
     appNamespace: bitiq-local
     baseDomain: apps-crc.testing                    # OpenShift Local default
-    platforms: linux/arm64
+    platforms: linux/amd64
     enableFrontendImageUpdate: true
   - name: sno
     clusterServer: https://kubernetes.default.svc

--- a/docs/LOCAL-CI-CD.md
+++ b/docs/LOCAL-CI-CD.md
@@ -21,7 +21,7 @@ Prereqs
 
 Defaults worth knowing
 
-- Platform filter for Image Updater: ENV=local defaults to `linux/arm64`; ENV=sno and ENV=prod default to `linux/amd64`. These are set per env in `charts/argocd-apps/values.yaml` under `envs[].platforms` and passed into the umbrella chart. If your local cluster is x86_64, either change `local` to `linux/amd64` or publish multi‑arch images.
+- Platform filter for Image Updater: ENV=local, ENV=sno, and ENV=prod now default to `linux/amd64`. These are set per env in `charts/argocd-apps/values.yaml` under `envs[].platforms` and passed into the umbrella chart. If your local cluster is arm64 (for example, Apple Silicon CRC), either publish multi‑arch images or override `local` to `linux/arm64`.
 - Frontend image updates are enabled for `local`. Make sure the `toy-web` image is published to Quay (or set `enableFrontendImageUpdate: false` if you want to skip the frontend flow). If your repository is private, add a pull secret via `imageUpdater.pullSecret` so tag listing works.
 
 1) Bootstrap apps and operators


### PR DESCRIPTION
## Summary
- default the ApplicationSet local imageUpdater platform to linux/amd64 so CRC on x86_64 works without manual overrides
- refresh README and docs/LOCAL-CI-CD.md to note that arm64 clusters should override the platform filter

## Testing
- make template
- make lint