### PR TITLE
fix(docs): correct OpenShift CLI download URL for OCP 4.19 (Ubuntu local)

### DIFF
--- a/docs/LOCAL-RUNBOOK-UBUNTU.md
+++ b/docs/LOCAL-RUNBOOK-UBUNTU.md
@@ -38,11 +38,15 @@ This guide walks through running the full ENV=local GitOps workflow on a remote 
 
 ## 1) Install CLI tooling
 
-- **OpenShift CLI (`oc`)**: download the matching release from Red Hat. Example (4.15):
+- **OpenShift CLI (`oc`)**: download the matching release from Red Hat. Example (4.19):
 
   ```bash
-  curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/oc-linux.tar.gz
-  tar -xzf oc-linux.tar.gz oc kubectl
+  curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.19/openshift-client-linux.tar.gz
+  # Validate the archive looks correct (optional but recommended)
+  file openshift-client-linux.tar.gz
+  tar -tzf openshift-client-linux.tar.gz | grep -E '^(oc|kubectl)$'
+  # Extract the oc and kubectl binaries
+  tar -xzf openshift-client-linux.tar.gz oc kubectl
   sudo mv oc kubectl /usr/local/bin/
   oc version
   ```
@@ -223,4 +227,3 @@ make validate
 - **Git webhook timeouts**: confirm the ngrok tunnel is running and your server allows outbound HTTPS.
 
 Refer back to `README.md`, `docs/LOCAL-CI-CD.md`, and `docs/LOCAL-SETUP.md` for deeper troubleshooting and background.
-


### PR DESCRIPTION
Problem
- docs/LOCAL-RUNBOOK-UBUNTU.md used a non-existent artifact name (`oc-linux.tar.gz`). The mirror returns a tiny HTML 404 page, causing `tar -xzf` to fail.

Fix
- Switch to the correct artifact: `openshift-client-linux.tar.gz`.
- Pin to OCP 4.19 channel path: `latest-4.19` (alternatively `stable-4.19`).
- Add quick validation before extracting (check `file` output and list archive members).
- Update the extract line to reference the correct filename.

Scope / impact
- ENV: local only (Ubuntu/CRC runbook). No changes to charts or cluster behavior.
- No operator channels or defaults touched.

Validation
- `curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.19/openshift-client-linux.tar.gz`
- `file openshift-client-linux.tar.gz` → application/x-tar
- `tar -tzf openshift-client-linux.tar.gz | grep -E '^(oc|kubectl)$'` shows the binaries
- `tar -xzf openshift-client-linux.tar.gz oc kubectl && sudo mv oc kubectl /usr/local/bin/`
- `oc version && kubectl version --client`

Notes
- If you prefer the stable channel, replace `latest-4.19` with `stable-4.19`.
- I also scanned the repo for other incorrect client URLs; none found.
